### PR TITLE
parse,gen: read command overview with some quick and dirty word wrapping

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -253,11 +253,30 @@ func parseComments(cg *ast.CommentGroup) clapData {
 	for i := range lines {
 		if lines[i] == "" {
 			cd.Blurb = strings.Join(lines[:i], " ")
+			lines = lines[i+1:]
 			break
 		}
 	}
 
-	// todo(steve): read in the longer description if it's there
+	// The remaining groups of non-empty lines (if any) are considered the paragraphs of
+	// the item's "overview" (only ever used for commands, not for options or arguments).
+	paras := make([]string, 0, 2)
+	var p strings.Builder
+	for i := range lines {
+		if lines[i] != "" {
+			p.WriteString(lines[i])
+			p.WriteByte('\n')
+		} else {
+			if i > 0 && lines[i-1] != "" {
+				paras = append(paras, p.String())
+				p.Reset()
+			}
+		}
+	}
+	if p.Len() > 0 {
+		paras = append(paras, p.String())
+	}
+	cd.overview = paras
 
 	return cd
 }

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func (v buildVersionInfo) String() string {
 
 type clapData struct {
 	Blurb    string
-	longDesc string
+	overview []string // paragraphs
 	configs  []clapConfig
 }
 

--- a/tmpls/usagefunc.go.tmpl
+++ b/tmpls/usagefunc.go.tmpl
@@ -1,6 +1,10 @@
 
 func (*{{ .TypeName }}) printUsage(to *os.File) {
 	fmt.Fprintf(to, `{{ .Parents }}{{ .UsgName }} - {{ .Data.Blurb }}
+{{- with .Overview }}
+
+overview:
+{{ . }}{{ end }}
 
 usage:{{ range .UsageLines }}
    {{ . }}{{ end }}


### PR DESCRIPTION
This change reads the remaining comments on command structs (after configs and blurb had been read) and formats them into the overview text in the usage message.