### PR TITLE
gen: use `.gen.go` extension for generated files instead of plain `.go`

### DIFF
--- a/clap.gen.go
+++ b/clap.gen.go
@@ -67,10 +67,6 @@ argsLoop:
 			break
 		}
 		k, eqv, hasEq := optParts(args[i][1:])
-		if k == "h" || k == "help" {
-			u.printUsage(os.Stdout)
-			os.Exit(0)
-		}
 		for z := range data {
 			if k == data[z].long || k == data[z].short {
 				switch v := data[z].v.(type) {
@@ -89,6 +85,10 @@ argsLoop:
 				}
 				continue argsLoop
 			}
+		}
+		if k == "h" || k == "help" {
+			u.printUsage(os.Stdout)
+			os.Exit(0)
 		}
 		claperr("unknown option '%s'\n", k)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ func gen(c *goclap) error {
 		return fmt.Errorf("generating: %w", err)
 	}
 
-	outName := "./clap.go"
+	outName := "./clap.gen.go"
 	if c.outFilePath != "" {
 		outName = c.outFilePath
 	}


### PR DESCRIPTION
Closes #35.